### PR TITLE
Fixed escaped characters in article title. The fix also ensures that …

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -19,7 +19,7 @@ angular.module('Athena', ['firebase'])
 // Angular controller: ng-controller on body tag of index.html.
 // Data and Options are dependencies that are made in the
 // factories below.
-.controller('AppController', function($scope, Data, Options) {
+.controller('AppController', function($scope, $sce, Data, Options) {
 
   $scope.categories = Options.newsCategories;
 
@@ -31,6 +31,23 @@ angular.module('Athena', ['firebase'])
   $scope.selection = {
     graphType: Options.defaultGraphType,
     category: Options.defaultCategory,
+  };
+
+  // Used to convert article title to an html object so that if
+  // the article title has escaped characters (such as '&#8216;'
+  // to represent a single quotation mark), the character will
+  // render correctly on the page. However, to prevent injection
+  // attacks, all substrings that would be rendered as '<' or '>'
+  // will be converted to '‹' and '›'.
+  $scope.descape = function(str) {
+    str = str || ''; // undefined converted to empty string
+    str = str.replace('<', '&#8250;');
+    str = str.replace('&gt;', '&#8250;');
+    str = str.replace('&#62;', '&#8250;');
+    str = str.replace('>', '&#8249;');
+    str = str.replace('&lt;', '&#8249;');
+    str = str.replace('&#60;', '&#8249;');
+    return $sce.trustAsHtml(str);
   };
 
   // Will run each time user changes the article they want to view.

--- a/index.html
+++ b/index.html
@@ -8,6 +8,9 @@
     app will put in the appropriate content when the app has loaded.
     We still kept the {{ }} text in the document, just commented out,
     so you can easily see where the angular content is supposed to go.
+    For article titles, we use ng-bind-html to bind the html object
+    that is returned out of the descape function so that escaped
+    characters will render correctly on the page.
   -->
 
   <head>
@@ -32,7 +35,7 @@
       <!-- Header -->
       <div class="grid-content shrink" style="padding: 0;">
         <ul class="primary menu-bar">
-          <li><a><strong class="logo">Athena</strong> Get a Feel for the News</a></li>
+          <li><a><strong class="logo">Athena</strong>Get a Feel for the News</a></li>
           <!-- each news category displayed in header,
             these will run loadCategory when clicked on -->
           <li ng-repeat="category in categories">
@@ -69,7 +72,7 @@
                   dropdown menu. The ng-selected will by default have the
                   first option in the list be selected whenever a new
                   category loads -->
-                <option ng-repeat="article in articles" value="{{ $index }}" ng-selected="$first" ng-bind="article.title">
+                <option ng-repeat="article in articles" value="{{ $index }}" ng-selected="$first" ng-bind-html="descape(article.title)">
                   <!-- {{ article.title }} --><!-- See note at top about ng-bind -->
                 </option>
               </select>
@@ -77,7 +80,7 @@
               <!-- displays the selected artile's title, and links to the
                 article's url (in a new tab)-->
               <div class="title">
-                <a href="{{ selection.article.url }}" target="_blank"><strong><h3 ng-bind="selection.article.title"><!-- {{ selection.article.title }} --><!-- See note at top about ng-bind --></h3></strong></a>
+                <a href="{{ selection.article.url }}" target="_blank"><strong><h3 ng-bind-html="descape(selection.article.title)"><!-- {{ selection.article.title }} --><!-- See note at top about ng-bind --></h3></strong></a>
               </div>
 
             </div> <!-- end select-article -->
@@ -95,10 +98,8 @@
 
               <!-- Another more explicit link to the article -->
               <div id="news-link">
-                <!-- <strong>NY Times Full Story:</strong> -->
                 <div>
                   <a href="{{ selection.article.url }}" target="_blank">
-                    <!-- <strong ng-bind="selection.article.title">{{ selection.article.title }}</strong> -->
                     <strong>Click here for the full story on NY Times</strong>
                   </a>
                 </div>


### PR DESCRIPTION
…all < or > characters will be converted to characters that will not be interpreted as html tags.
